### PR TITLE
Update README with correct initialization of client

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ require 'puppetdb'
 # Defaults to latest API version.
 
 # non-ssl
-client = PuppetDB::Client({:server => 'http://localhost:8080'})
+client = PuppetDB::Client.new({:server => 'http://localhost:8080'})
 
 # ssl
-client = PuppetDB::Client({
+client = PuppetDB::Client.new({
     :server => 'https://localhost:8081',
     :pem    => {
         :key     => "keyfile",


### PR DESCRIPTION
This commit corrects the README documentation of instantiating 
PuppetDB::Client object. Previous to this commit, the instructions ommitted
calling the PuppetDB::Client#new method, instead instructing users to call the
PuppetDB#Client method, which doesn't exist
