### PR TITLE
Fix calling the path for calling PuppetDB API

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ client = PuppetDB::Client({
         :ca_file => "cafile"
     }})
 
-response = client.request([:and,
+response = client.request('/facts', [:and,
                  [:'=', ['fact', 'kernel'], 'Linux'],
                  [:>, ['fact', 'uptime_days'], 30]]], {:limit => 10})
 nodes = response.data

--- a/lib/puppetdb/client.rb
+++ b/lib/puppetdb/client.rb
@@ -84,7 +84,7 @@ module PuppetDB
       query = PuppetDB::Query.maybe_promote(query)
       json_query = query.build()
 
-      path = "/" + endpoint
+      path = self.class.base_uri + endpoint
 
       filtered_opts = {'query' => json_query}
       opts.each do |k,v|


### PR DESCRIPTION
Previous to this commit, the Puppet::Client#request method incorrectly 
constructed the path to call the PuppetDB API.  This commit uses the value
returned from self.class.base_uri to construct it correctly.

Further, the REAME did not specify the need to call specify which endpoint to
call on the PuppetDB API.  This commit updates the README to reflect the
proper use of the PuppetDB::Client#request method
