### PR TITLE
Feature/fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ client = PuppetDB::Client.new({
         'ca_file' => "cafile"
     }})
 
-response = client.request('nodes',
+response = client.request(
+  'nodes',
   [:and,
     [:'=', ['fact', 'kernel'], 'Linux'],
     [:>, ['fact', 'uptime_days'], 30]


### PR DESCRIPTION
The example in the README didn't work out-of-the-box. Turns out that there are discrepancies/mistakes in the README.

Regarding the hash keys strings vs/ symbols issue, why do you use a combination of symbol keys and string keys? Why not use one or the other? Why use symbols then convert to strings internallly?

R.
