### PR TITLE
Do not send a query parameter if nil

### DIFF
--- a/lib/puppetdb/client.rb
+++ b/lib/puppetdb/client.rb
@@ -86,7 +86,12 @@ module PuppetDB
 
       path = "/" + endpoint
 
-      filtered_opts = {'query' => json_query}
+      if (json_query != nil.to_json)
+        filtered_opts = {'query' => json_query}
+      else 
+        filtered_opts = { }
+      end
+
       opts.each do |k,v|
         if k == :counts_filter
           filtered_opts['counts-filter'] = JSON.dump(v)

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -152,6 +152,24 @@ describe 'request' do
     client.request('/foo', [1,2,3])
   end
 
+  it 'works with a nil query' do
+    client = PuppetDB::Client.new(settings)
+
+    mock_response = mock()
+    mock_response.expects(:code).returns(200)
+    mock_response.expects(:headers).returns({'X-Records' => 0})
+    mock_response.expects(:parsed_response).returns([])
+    
+    PuppetDB::Client.expects(:get).returns(mock_response).at_least_once.with() do |path, opts|
+      opts == {
+        :query => {}
+      }
+    end
+    
+    client.request('/foo', nil)
+    
+  end
+
   it 'processes options correctly' do
     client = PuppetDB::Client.new(settings)
 


### PR DESCRIPTION
I believe this fixes #8 - if the query parameter is nil (evaluates to "null" in json), then don't send the query parameter at all. This makes the query parameter optional (as per the PuppetDB API spec).

It might also be possible to set query=nil as a default in def request(endpoint, query=nil, opts={}) but I decided to leave this alone.
