### PR TITLE
Allow usage of unauthenticated PuppetDB over SSL

### DIFF
--- a/lib/puppetdb/client.rb
+++ b/lib/puppetdb/client.rb
@@ -94,7 +94,7 @@ module PuppetDB
 
       debug("#{path} #{json_query} #{opts}")
 
-      ret = self.class.get(path, query: filtered_opts)
+      ret = self.class.get(path, body: filtered_opts)
       raise_if_error(ret)
 
       total = ret.headers['X-Records']

--- a/lib/puppetdb/client.rb
+++ b/lib/puppetdb/client.rb
@@ -60,8 +60,8 @@ module PuppetDB
       end
 
       @use_ssl = scheme == 'https'
-      if @use_ssl
-        unless pem && hash_includes?(pem, 'key', 'cert', 'ca_file')
+      if @use_ssl && pem
+        unless hash_includes?(pem, 'key', 'cert', 'ca_file')
           error_msg = 'Configuration error: https:// specified but pem is missing or incomplete. It requires cert, key, and ca_file.'
           raise error_msg
         end

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -79,12 +79,12 @@ describe 'SSL support' do
       expect(r.use_ssl).to eq(true)
     end
 
-    it 'does not tolerate lack of pem' do
+    it 'tolerates lack of pem' do
       settings = {
         server: 'https://localhost:8081'
       }
 
-      -> { PuppetDB::Client.new(settings) }.should raise_error
+      -> { PuppetDB::Client.new(settings) }.should_not raise_error
     end
 
     it 'does not tolerate lack of key' do

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -147,7 +147,7 @@ describe 'request' do
     mock_response.expects(:parsed_response).returns([])
 
     PuppetDB::Client.expects(:get).returns(mock_response).at_least_once.with do |_path, opts|
-      opts[:query] == { 'query' => '[1,2,3]' }
+      opts[:body] == { 'query' => '[1,2,3]' }
     end
     client.request('/foo', [1, 2, 3])
   end
@@ -162,7 +162,7 @@ describe 'request' do
 
     PuppetDB::Client.expects(:get).returns(mock_response).at_least_once.with do |_path, opts|
       opts == {
-        query: {
+        body: {
           'query'         => '[1,2,3]',
           'limit'         => 10,
           'counts-filter' => '[4,5,6]',

--- a/spec/unit/query_spec.rb
+++ b/spec/unit/query_spec.rb
@@ -79,12 +79,12 @@ describe 'SSL support' do
       expect(r.use_ssl).to eq(true)
     end
 
-    it 'does not tolerate lack of pem' do
+    it 'tolerates lack of pem' do
       settings = {
         server: 'https://localhost:8081'
       }
 
-      -> { PuppetDB::Client.new(settings) }.should raise_error
+      -> { PuppetDB::Client.new(settings) }.should_not raise_error
     end
 
     it 'does not tolerate lack of key' do

--- a/spec/unit/query_spec.rb
+++ b/spec/unit/query_spec.rb
@@ -147,7 +147,7 @@ describe 'request' do
     mock_response.expects(:parsed_response).returns([])
 
     PuppetDB::Client.expects(:get).returns(mock_response).at_least_once.with do |_path, opts|
-      opts[:query] == { 'query' => '[1,2,3]' }
+      opts[:body] == { 'query' => '[1,2,3]' }
     end
     client.request('/foo', [1, 2, 3])
   end
@@ -162,7 +162,7 @@ describe 'request' do
 
     PuppetDB::Client.expects(:get).returns(mock_response).at_least_once.with do |_path, opts|
       opts == {
-        query: {
+        body: {
           'query'         => '[1,2,3]',
           'limit'         => 10,
           'counts-filter' => '[4,5,6]',


### PR DESCRIPTION
On some occasions the user might have a PuppetDB installation serving the API from an SSL-enabled server with no authentication mechanism. In these cases the pem settings are not necessary and should be avoided.
