### PR TITLE
Add command API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ client = PuppetDB::Client.new({
         'ca_file' => "cafile"
     }})
 
+# Query API
+
 response = client.request(
   'nodes',
   [:and,
@@ -49,6 +51,14 @@ debian = PuppetDB::Query[:'=', [:fact, 'osfamily'], 'Debian']
 client.request uptime.and(debian)
 client.request uptime.and(redhat)
 client.request uptime.and(debian.or(redhat))
+
+# Command API
+
+client.command(
+  'deactivate node',
+  {'certname' => 'test1', 'producer_timestamp' => '2015-01-01'},
+  3
+)
 ```
 
 ## Tests

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -176,3 +176,32 @@ describe 'request' do
                                                      foo_bar: 'foo')
   end
 end
+
+describe 'command' do
+  settings = { server: 'http://localhost' }
+  command = 'deactivate node'
+  payload = { 'certname' => 'test1', 'producer_timestamp' => '2015-01-01' }
+  payload_version = 3
+
+  it 'processes options correctly' do
+    client = PuppetDB::Client.new(settings)
+
+    mock_response = mock
+    mock_response.expects(:code).returns(200)
+    mock_response.expects(:parsed_response).returns([])
+
+    PuppetDB::Client.expects(:post).returns(mock_response).at_least_once.with do |_path, opts|
+      expect(opts).to eq(query: {
+                           'command' => command,
+                           'version' => payload_version,
+                           'certname' => 'test1'
+                         },
+                         body: payload.to_json,
+                         headers: {
+                           'Accept' => 'application/json',
+                           'Content-Type' => 'application/json'
+                         })
+    end
+    client.command(command, payload, payload_version)
+  end
+end


### PR DESCRIPTION
This is an extended version of https://github.com/voxpupuli/puppetdb-ruby/pull/5 with tests and PuppetDB v4 support.

There are a few breaking changes because QueryAPI and CommandAPI has different endpoints and API versions.

My changes are successfully tested on Puppet2016 with the 'replace catalog' and 'replace facts' commands. 