### PR TITLE
Add PE RBAC token support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 Each new release typically also includes the latest modulesync defaults.
 These should not impact the functionality of the module.
 
+## Unreleased
+
+**Implemented enhancements:**
+
+- Add AccessDeniedError, UnauthorizedError and ForbiddenError exceptions
+- Silence warnings about unspecified exception types in spec tests
+- Add support for Puppet Enterprise RBAC token authentication
+- Add support for loading configuration defaults from Puppet Enterprise Client Tools configuration files
+  <https://puppet.com/docs/pe/2018.1/installing_pe_client_tools.html#configuring-and-using-client-tools>
+
 ## [v1.1.1](https://github.com/voxpupuli/puppetdb-ruby/tree/v1.1.1) (2017-08-17)
 [Full Changelog](https://github.com/voxpupuli/puppetdb-ruby/compare/1.1.0...v1.1.1)
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Non-SSL:
 client = PuppetDB::Client.new({:server => 'http://localhost:8080'})
 ```
 
-SSL:
+SSL with cert-based authentication:
 ``` ruby
 client = PuppetDB::Client.new({
     :server => 'https://localhost:8081',
@@ -50,6 +50,24 @@ client = PuppetDB::Client.new({
         'ca_file' => "cafile"
     }})
 ```
+
+SSL with PE RBAC token based authentication:
+``` ruby
+client = PuppetDB::Client.new({
+    :server => "https://localhost:8081",
+    :token  => "my_pe_rbac_token",
+    :cacert => "/path/to/cacert.pem",
+    })
+```
+
+SSL with PE RBAC token based authentication, using all settings from PE Client Tools configurations:
+``` ruby
+client = PuppetDB::Client.new()
+```
+
+Note: When using cert-based authentication you must specify the full pem structure. When using token based authentication
+you must NOT provide the pem structure and instead pass ':token' and ':cacert' (or allow them to be read from the
+PE Client Tools configuration).
 
 #### Query API usage
 

--- a/lib/puppetdb.rb
+++ b/lib/puppetdb.rb
@@ -2,5 +2,6 @@ require 'puppetdb/version'
 require 'puppetdb/client'
 require 'puppetdb/query'
 require 'puppetdb/response'
+require 'puppetdb/error'
 
 module PuppetDB; end

--- a/lib/puppetdb.rb
+++ b/lib/puppetdb.rb
@@ -3,5 +3,6 @@ require 'puppetdb/client'
 require 'puppetdb/query'
 require 'puppetdb/response'
 require 'puppetdb/error'
+require 'puppetdb/config'
 
 module PuppetDB; end

--- a/lib/puppetdb/client.rb
+++ b/lib/puppetdb/client.rb
@@ -1,14 +1,9 @@
 require 'httparty'
 require 'logger'
 
-module PuppetDB
-  class APIError < RuntimeError
-    attr_reader :code, :response
-    def initialize(response)
-      @response = response
-    end
-  end
+require 'puppetdb/error'
 
+module PuppetDB
   class FixSSLConnectionAdapter < HTTParty::ConnectionAdapter
     def attach_ssl_certificates(http, options)
       http.cert    = OpenSSL::X509::Certificate.new(File.read(options[:pem]['cert']))
@@ -74,6 +69,8 @@ module PuppetDB
     end
 
     def raise_if_error(response)
+      raise UnauthorizedError, response if response.code == 401
+      raise ForbiddenError, response if response.code == 403
       raise APIError, response if response.code.to_s =~ %r{^[4|5]}
     end
 

--- a/lib/puppetdb/config.rb
+++ b/lib/puppetdb/config.rb
@@ -1,0 +1,87 @@
+require 'json'
+
+class PuppetDB::Config
+  def initialize(overrides = nil, load_files = false)
+    @overrides = {}
+    overrides.each { |k, v| @overrides[k.to_s] = v } unless overrides.nil?
+
+    @load_files = load_files
+  end
+
+  def load_file(path)
+    File.open(path) { |f| JSON.parse(f.read)['puppetdb'] }
+  end
+
+  def puppetlabs_root
+    '/etc/puppetlabs'
+  end
+
+  def global_conf
+    File.join(puppetlabs_root, 'client-tools', 'puppetdb.conf')
+  end
+
+  def user_root
+    File.join(Dir.home, '.puppetlabs')
+  end
+
+  def user_conf
+    File.join(user_root, 'client-tools', 'puppetdb.conf')
+  end
+
+  def default_cacert
+    "#{puppetlabs_root}/puppet/ssl/certs/ca.pem"
+  end
+
+  def defaults
+    {
+      'cacert' => default_cacert,
+      'token-file' => File.join(user_root, 'token')
+    }
+  end
+
+  def load_config
+    config = defaults
+    if @load_files
+      if File.exist?(global_conf) && File.readable?(global_conf)
+        config = config.merge(load_file(global_conf))
+      end
+
+      if @overrides['config-file']
+        config = config.merge(load_file(@overrides['config-file']))
+      elsif File.exist?(user_conf) && File.readable?(user_conf)
+        config = config.merge(load_file(user_conf))
+      end
+    end
+
+    config.merge(@overrides)
+  end
+
+  def config
+    @config ||= load_config
+  end
+
+  def load_token
+    if @config.include?('token')
+      @config['token']
+    elsif File.readable?(config['token-file'])
+      File.read(config['token-file']).strip
+    end
+  end
+
+  def token
+    @token ||= load_token
+  end
+
+  def server_urls
+    return [config['server']] unless config['server'].nil?
+    config['server_urls'] || []
+  end
+
+  def server
+    server_urls.first || {}
+  end
+
+  def [](key)
+    @config[key]
+  end
+end

--- a/lib/puppetdb/error.rb
+++ b/lib/puppetdb/error.rb
@@ -1,0 +1,17 @@
+module PuppetDB
+  class APIError < RuntimeError
+    attr_reader :code, :response
+    def initialize(response)
+      @response = response
+    end
+  end
+
+  class AccessDeniedError < APIError
+  end
+
+  class ForbiddenError < AccessDeniedError
+  end
+
+  class UnauthorizedError < AccessDeniedError
+  end
+end

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -27,14 +27,28 @@ describe 'raise_if_error' do
     response = mock
     response.stubs(:code).returns(400)
 
-    -> { PuppetDB::Client.new(settings).raise_if_error(response) }.should raise_error
+    -> { PuppetDB::Client.new(settings).raise_if_error(response) }.should raise_error(PuppetDB::APIError)
   end
 
   it 'works with 5xx' do
     response = mock
     response.stubs(:code).returns(500)
 
-    -> { PuppetDB::Client.new(settings).raise_if_error(response) }.should raise_error
+    -> { PuppetDB::Client.new(settings).raise_if_error(response) }.should raise_error(PuppetDB::APIError)
+  end
+
+  it 'raises UnauthorizedError with 401' do
+    response = mock
+    response.stubs(:code).returns(401)
+
+    -> { PuppetDB::Client.new(settings).raise_if_error(response) }.should raise_error(PuppetDB::UnauthorizedError)
+  end
+
+  it 'raises ForbiddenError with 403' do
+    response = mock
+    response.stubs(:code).returns(403)
+
+    -> { PuppetDB::Client.new(settings).raise_if_error(response) }.should raise_error(PuppetDB::ForbiddenError)
   end
 
   it 'ignores 2xx' do
@@ -96,7 +110,7 @@ describe 'SSL support' do
         }
       }
 
-      -> { PuppetDB::Client.new(settings) }.should raise_error
+      -> { PuppetDB::Client.new(settings) }.should raise_error(RuntimeError)
     end
 
     it 'does not tolerate lack of cert' do
@@ -108,7 +122,7 @@ describe 'SSL support' do
         }
       }
 
-      -> { PuppetDB::Client.new(settings) }.should raise_error
+      -> { PuppetDB::Client.new(settings) }.should raise_error(RuntimeError)
     end
 
     it 'does not tolerate lack of ca_file' do
@@ -120,7 +134,7 @@ describe 'SSL support' do
         }
       }
 
-      -> { PuppetDB::Client.new(settings) }.should raise_error
+      -> { PuppetDB::Client.new(settings) }.should raise_error(RuntimeError)
     end
   end
 
@@ -130,7 +144,7 @@ describe 'SSL support' do
         'server' => 'localhost:8080'
       }
 
-      -> { PuppetDB::Client.new(settings) }.should raise_error
+      -> { PuppetDB::Client.new(settings) }.should raise_error(RuntimeError)
     end
   end
 end
@@ -142,7 +156,7 @@ describe 'request' do
     client = PuppetDB::Client.new(settings)
 
     mock_response = mock
-    mock_response.expects(:code).returns(200)
+    mock_response.expects(:code).at_least_once.returns(200)
     mock_response.expects(:headers).returns('X-Records' => 0)
     mock_response.expects(:parsed_response).returns([])
 
@@ -156,7 +170,7 @@ describe 'request' do
     client = PuppetDB::Client.new(settings)
 
     mock_response = mock
-    mock_response.expects(:code).returns(200)
+    mock_response.expects(:code).at_least_once.returns(200)
     mock_response.expects(:headers).returns('X-Records' => 0)
     mock_response.expects(:parsed_response).returns([])
 
@@ -180,7 +194,7 @@ describe 'request' do
     client = PuppetDB::Client.new(settings)
 
     mock_response = mock
-    mock_response.expects(:code).returns(200)
+    mock_response.expects(:code).at_least_once.returns(200)
     mock_response.expects(:headers).returns('X-Records' => 0)
     mock_response.expects(:parsed_response).returns([])
 
@@ -206,7 +220,7 @@ describe 'command' do
     client = PuppetDB::Client.new(settings)
 
     mock_response = mock
-    mock_response.expects(:code).returns(200)
+    mock_response.expects(:code).at_least_once.returns(200)
     mock_response.expects(:parsed_response).returns([])
 
     PuppetDB::Client.expects(:post).returns(mock_response).at_least_once.with do |_path, opts|

--- a/spec/unit/query_spec.rb
+++ b/spec/unit/query_spec.rb
@@ -27,14 +27,14 @@ describe 'raise_if_error' do
     response = mock
     response.stubs(:code).returns(400)
 
-    -> { PuppetDB::Client.new(settings).raise_if_error(response) }.should raise_error
+    -> { PuppetDB::Client.new(settings).raise_if_error(response) }.should raise_error(RuntimeError)
   end
 
   it 'works with 5xx' do
     response = mock
     response.stubs(:code).returns(500)
 
-    -> { PuppetDB::Client.new(settings).raise_if_error(response) }.should raise_error
+    -> { PuppetDB::Client.new(settings).raise_if_error(response) }.should raise_error(RuntimeError)
   end
 
   it 'ignores 2xx' do
@@ -96,7 +96,7 @@ describe 'SSL support' do
         }
       }
 
-      -> { PuppetDB::Client.new(settings) }.should raise_error
+      -> { PuppetDB::Client.new(settings) }.should raise_error(RuntimeError)
     end
 
     it 'does not tolerate lack of cert' do
@@ -108,7 +108,7 @@ describe 'SSL support' do
         }
       }
 
-      -> { PuppetDB::Client.new(settings) }.should raise_error
+      -> { PuppetDB::Client.new(settings) }.should raise_error(RuntimeError)
     end
 
     it 'does not tolerate lack of ca_file' do
@@ -120,7 +120,7 @@ describe 'SSL support' do
         }
       }
 
-      -> { PuppetDB::Client.new(settings) }.should raise_error
+      -> { PuppetDB::Client.new(settings) }.should raise_error(RuntimeError)
     end
   end
 
@@ -130,7 +130,7 @@ describe 'SSL support' do
         'server' => 'localhost:8080'
       }
 
-      -> { PuppetDB::Client.new(settings) }.should raise_error
+      -> { PuppetDB::Client.new(settings) }.should raise_error(RuntimeError)
     end
   end
 end
@@ -142,7 +142,7 @@ describe 'request' do
     client = PuppetDB::Client.new(settings)
 
     mock_response = mock
-    mock_response.expects(:code).returns(200)
+    mock_response.expects(:code).at_least_once.returns(200)
     mock_response.expects(:headers).returns('X-Records' => 0)
     mock_response.expects(:parsed_response).returns([])
 
@@ -156,7 +156,7 @@ describe 'request' do
     client = PuppetDB::Client.new(settings)
 
     mock_response = mock
-    mock_response.expects(:code).returns(200)
+    mock_response.expects(:code).at_least_once.returns(200)
     mock_response.expects(:headers).returns('X-Records' => 0)
     mock_response.expects(:parsed_response).returns([])
 


### PR DESCRIPTION
Puppet Enterprise RBAC allows for token-based authentication to PuppetDB. This enables token-based authentication and also enables automatic configuration of PuppetDB based on the PE Client Tools configuration files, which are likely to be found on any system using token-based authentication.