### PR TITLE
Add features to client to support pupppetdb cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,23 @@ client.status
 # }
 ```
 
+#### Export an archive of PuppetDB
+
+You can [`export`](https://puppet.com/docs/puppetdb/5.1/anonymization.html#using-the-export-command) an archive
+of your PuppetDB to a file. Optionally you can override the `anonymization_profile` (default: none).
+
+``` ruby
+client.export('path/for/new_puppetdb_export.tar.gz', anonymization_profile: :high)
+```
+
+#### Import an archive into PuppetDB
+
+Once you have a PuppetDB export, it can be loaded into PuppetDB with [`import`](https://puppet.com/docs/puppetdb/5.1/anonymization.html#using-the-import-command).
+
+``` ruby
+client.import('path/to/existing_puppetdb_export.tar.gz')
+```
+
 ## Tests
 
 ```

--- a/README.md
+++ b/README.md
@@ -167,6 +167,43 @@ client.command(
 
 See the PuppetDB [Commands Endpoint Docs](https://docs.puppet.com/puppetdb/5.0/api/command/v1/commands.html) for more information.
 
+#### Query the status endpoint(s)
+
+You can get the status of all configured PuppetDB's by querying the `/status/v1/services` endpoints.
+``` ruby
+client.status
+
+# The result will be of the form (one entry per server)
+# {
+#   "http://localhost:8080": {
+#     "puppetdb-status": {
+#       "service_version": "6.3.1-SNAPSHOT",
+#       "service_status_version": 1,
+#       "detail_level": "info",
+#       "state": "running",
+#       "status": {
+#         "maintenance_mode?": false,
+#         "queue_depth": 0,
+#         "read_db_up?": true,
+#         "write_db_up?": true
+#       },
+#       "active_alerts": [
+#       ]
+#     },
+#     "status-service": {
+#       "service_version": "1.1.0",
+#       "service_status_version": 1,
+#       "detail_level": "info",
+#       "state": "running",
+#       "status": {
+#       },
+#       "active_alerts": [
+#       ]
+#     }
+#   }
+# }
+```
+
 ## Tests
 
 ```

--- a/README.md
+++ b/README.md
@@ -60,6 +60,15 @@ client = PuppetDB::Client.new({
     })
 ```
 
+Configure connections to multiple PuppetDB's via `server_urls`
+``` ruby
+client = PuppetDB::Client.new({
+    :server_urls => "https://localhost:8081,https://localhost:8083",
+    :token  => "my_pe_rbac_token",
+    :cacert => "/path/to/cacert.pem",
+    })
+```
+
 SSL with PE RBAC token based authentication, using all settings from PE Client Tools configurations:
 ``` ruby
 client = PuppetDB::Client.new()
@@ -99,6 +108,21 @@ debian = PuppetDB::Query[:'=', [:fact, 'osfamily'], 'Debian']
 client.request uptime.and(debian)
 client.request uptime.and(redhat)
 client.request uptime.and(debian.or(redhat))
+```
+
+If you have configured multiple PuppetDB's via [`server_urls`](https://puppet.com/docs/puppetdb/latest/pdb_client_tools.html#step-3-install-and-configure-the-puppetdb-cli)
+then you can query in `:failover` mode. This will query each PuppetDB in `server_urls`
+in order until it gets a successful response. It will fail with an `APIError` only if all queries fail.
+
+``` ruby
+response = client.request(
+  'nodes',
+  [:"=", "certname", "foo"],
+  {
+    :limit => 10
+    :query_mode => :failover
+  }
+)
 ```
 
 See the [PuppetDB API Docs](https://docs.puppet.com/puppetdb/5.0/api/index.html) for more.

--- a/lib/puppetdb/client.rb
+++ b/lib/puppetdb/client.rb
@@ -102,6 +102,7 @@ module PuppetDB
         Response.new(ret.parsed_response, total)
       elsif query_mode == :failover
 
+        ret=nil
         @servers.each do |server|
           self.class.base_uri(server)
           ret = self.class.get(path, body: filtered_opts)
@@ -114,7 +115,7 @@ module PuppetDB
             debug("query on '#{server}' failed with #{ret.code}")
           end
         end
-        raise APIError, 'All queries failed (run again in debug mode to see the reason(s))'
+        raise APIError, ret
       else
         raise ArgumentError, "Query mode '#{query_mode}' is not supported (try :first or :failover)."
       end

--- a/lib/puppetdb/client.rb
+++ b/lib/puppetdb/client.rb
@@ -144,5 +144,22 @@ module PuppetDB
 
       Response.new(ret.parsed_response)
     end
+
+    def status
+      status_endpoint = '/status/v1/services'
+      status_map = {}
+
+      @servers.each do |server|
+        self.class.base_uri(server)
+        ret = self.class.get(status_endpoint)
+
+        status_map[server] = if ret.code >= 400
+                               { error: "Unable to build JSON object from server: #{server}" }
+                             else
+                               ret.parsed_response
+                             end
+      end
+      status_map
+    end
   end
 end

--- a/lib/puppetdb/config.rb
+++ b/lib/puppetdb/config.rb
@@ -74,6 +74,7 @@ class PuppetDB::Config
 
   def server_urls
     return [config['server']] unless config['server'].nil?
+    return config['server_urls'].split(',') if config['server_urls'].is_a?(String)
     config['server_urls'] || []
   end
 


### PR DESCRIPTION
Hi! We are re-writing the [PuppetDB CLI tool ](https://puppet.com/docs/puppetdb/latest/pdb_client_tools.html) in  Ruby, in order to support that and use this existing module we need to add a few features that I've divided into three parts. It's likely easier to review each commit separately as this PR got quite large.

* The first flushes out support for supporting `server_urls` and failover in querying
* The second adds querying the status endpoints for all configured PuppetDB's
* The third adds the import/export commands

I've tried to add tests and documentation in each, but let me know if I missed anything.