### PR TITLE
Fully support PuppetDB APIv4 query parameters

### DIFF
--- a/lib/puppetdb/config.rb
+++ b/lib/puppetdb/config.rb
@@ -42,13 +42,13 @@ class PuppetDB::Config
   def load_config
     config = defaults
     if @load_files
-      if File.exist?(global_conf) && File.readable?(global_conf)
+      if File.readable?(global_conf)
         config = config.merge(load_file(global_conf))
       end
 
       if @overrides['config-file']
         config = config.merge(load_file(@overrides['config-file']))
-      elsif File.exist?(user_conf) && File.readable?(user_conf)
+      elsif File.readable?(user_conf)
         config = config.merge(load_file(user_conf))
       end
     end

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -217,8 +217,8 @@ describe 'request' do
         body: {
           'query'         => '[1,2,3]',
           'limit'         => 10,
-          'counts-filter' => '[4,5,6]',
-          'foo-bar'       => 'foo'
+          'counts_filter' => '[4,5,6]',
+          'foo_bar'       => 'foo'
         }
       }
     end

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -144,6 +144,8 @@ describe 'SSL support' do
 
       before do
         Dir.stubs(:home).returns('/user/root')
+        File.stubs(:readable?).with('/etc/puppetlabs/client-tools/puppetdb.conf').returns(false)
+        File.stubs(:readable?).with('/user/root/.puppetlabs/client-tools/puppetdb.conf').returns(false)
         File.stubs(:readable?).with('/user/root/.puppetlabs/token').returns(true)
         File.stubs(:read).with('/user/root/.puppetlabs/token').returns('mytoken')
       end

--- a/spec/unit/query_spec.rb
+++ b/spec/unit/query_spec.rb
@@ -165,8 +165,8 @@ describe 'request' do
         body: {
           'query'         => '[1,2,3]',
           'limit'         => 10,
-          'counts-filter' => '[4,5,6]',
-          'foo-bar'       => 'foo'
+          'counts_filter' => '[4,5,6]',
+          'foo_bar'       => 'foo'
         }
       }
     end


### PR DESCRIPTION
The current behavior in the request method to transform query parameters from containing `_` to `-` is incompatible with the query parameters as found in the v4 query API, which all use `_`. This code omits the `_` to `-` transformation when configured to use the v4 API.

Also, it removes the special case on `counts-filter` to more generally support serializing values to JSON if the values are found to be arrays or hashes, which allows support for the other parameters which behavior similarly.